### PR TITLE
Restoring Switches from CN-Series

### DIFF
--- a/cn-series-airs-helm/helm/templates/pan-cni-configmap.yaml
+++ b/cn-series-airs-helm/helm/templates/pan-cni-configmap.yaml
@@ -53,11 +53,17 @@ data:
           "log_level": "debug",
           "appinfo_dir": "/var/log/pan-appinfo",
           "mode": "service",
-          "cloud": "gke",
+          {{- if or (eq .Values.deployTo "eks") (eq .Values.deployTo "aks") (eq .Values.deployTo "gke") }}
+          "cloud": "{{- .Values.deployTo }}",
+          {{- else if eq .Values.deployTo "openshift" }}
+          "cloudcni": "openshiftsdn",
+          {{- end }}  
           "dpservicename": "pan-ngfw-svc",
           "dpservicenamespace": "{{ .Values.namespace }}",
           "traffic_object_id": "{{ .Values.clusterid }}",
+          {{- if ne .Values.deployTo "aks" }}
           "firewall": [ "pan-fw" ],
+          {{- end }}
           "interfaces": ["eth0"],
           "interfacesip": [""],
           "interfacesmac": [""],
@@ -65,7 +71,13 @@ data:
           "fwtrustcidr": "{{ .Values.fwtrustcidr }}",
           "kubernetes": {
               "kubeconfig": "__KUBECONFIG_FILEPATH__",
+              {{- if eq .Values.deployTo "gke" }}
               "cni_bin_dir": "/home/kubernetes/bin",
+              {{- else if eq .Values.deployTo "openshift" }}
+              "cni_bin_dir": "/var/lib/cni/bin",
+              {{- else }}
+              "cni_bin_dir": "/opt/cni/bin",
+              {{- end }}
               "exclude_namespaces": [ ],
               "security_namespaces": [ "{{ .Values.namespace }}"]
           }

--- a/cn-series-airs-helm/helm/templates/pan-cni.yaml
+++ b/cn-series-airs-helm/helm/templates/pan-cni.yaml
@@ -64,13 +64,29 @@ spec:
                 configMapKeyRef:
                   name: pan-cni-config
                   key: cni_network_config
+            {{- if eq .Values.deployTo "openshift" }}
+            # Name of the CNI config file for our CNI plugin.
+            - name: CNI_CONF_NAME
+              value: "pan-cni.conf"
+            {{- else }}
             # Name of the primary CNI config file to add our CNI plugin.
             # This is optional. We always wait until this configured (if
             # configured) or any cni conf file is detected. If configured
             # pan-cni will wait until configured CNI conf becomes primary
             #- name: CNI_CONF_NAME
             #  value: "10-calico.conflist"
-            # 
+            {{- end }}
+            {{- if eq .Values.deployTo "openshift" }}
+            # Name of the directory for CNI config file for our CNI plugin.
+            - name: CNI_NET_DIR
+              value: "/etc/cni/multus/net.d"
+            {{- end }}
+            # Whether to deploy the configuration file as a plugin chain or as 
+            # a standalone file (for multus) in cni-conf-dir
+            {{- if eq .Values.deployTo "openshift" }}
+            - name: CHAINED_CNI_PLUGIN
+              value: "false"
+            {{- end }}
             # This is optional. After pan-cni insertion, delay for it to be
             # picked up/propogated before makring pan-cni-ready (default 30 seconds)
             #- name: CNI_READY_DELAY
@@ -94,10 +110,20 @@ spec:
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
+          {{- if eq .Values.deployTo "gke" }}
             path: /home/kubernetes/bin
+          {{- else if eq .Values.deployTo "openshift" }}
+            path: /var/lib/cni/bin
+          {{- else }}
+            path: /opt/cni/bin
+            {{- end }}
         - name: cni-net-dir
           hostPath:
+            {{- if eq .Values.deployTo "openshift" }}
+            path: /etc/cni/multus/net.d
+            {{- else }}
             path: /etc/cni/net.d
+            {{- end }}
         - name: appinfo
           hostPath:
             # app pod info's directory location on host

--- a/cn-series-airs-helm/helm/values.yaml
+++ b/cn-series-airs-helm/helm/values.yaml
@@ -17,3 +17,7 @@ namespace: kube-system
 
 # Kubernetes ClusterID value range 1-2048.
 clusterid: 1
+
+# The K8s environment 
+# Valid deployTo tags are: [gke|eks|aks|openshift|native]
+deployTo: "native"


### PR DESCRIPTION
restore switches in config to support openshift, native, gke, aks, eks

## Description

restore install switches from CN series repo to AIRS

## Motivation and Context

support of openshift, gke, eks, aks and native require this

## How Has This Been Tested?

tested on native (k8s)

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
